### PR TITLE
Add support to print object params

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,6 +22,7 @@ module.exports = function(config) {
 
     // list of files to exclude
     exclude: [
+      'src/all.d.ts'
     ],
 
     // test results reporter to use

--- a/src/all.d.ts
+++ b/src/all.d.ts
@@ -1,0 +1,6 @@
+declare module 'jasmine-data_driven_tests/src/all' {
+  export function all(description: string, dataset: any[], assertion: (...args: any[]) => void): void;
+  export function xall(description: string, dataset: any[], assertion: (...args: any[]) => void): void;
+  export function using(description: string, dataset: any[], assertion: (...args: any[]) => void): void;
+  export function xusing(description: string, dataset: any[], assertion: (...args: any[]) => void): void;
+}

--- a/src/all.js
+++ b/src/all.js
@@ -49,6 +49,8 @@ function createVariantDescription(description, args, index) {
 		}
 		else if (isArray(args[i])) {
 			variantDesc += toString.call(args[i]);
+		} else if( (typeof args[i] === "object") && (args[i] !== null) ) {
+			variantDesc += JSON.stringify(args[i]);
 		}
 		else {
 			variantDesc += String(args[i]);


### PR DESCRIPTION
There is lots of use cases where people use objects - an indication of which data set failed would be great rather than display <Object Object>